### PR TITLE
Allow for Jira links to be generated without the prefix for known projec...

### DIFF
--- a/scripts/msys_jira.coffee
+++ b/scripts/msys_jira.coffee
@@ -19,6 +19,18 @@
 baseurl = "http://jira.int.messagesystems.com/browse"
 
 module.exports = (robot) ->
-  robot.hear /jira\s*([A-Za-z]{1,10}-[0-9]+)\b/i, (msg) ->
-    msg.send "#{baseurl}/#{msg.match[1]}"
+
+  regex = /// (
+    ?: jira\s*([A-Za-z]{1,10}-[0-9]+)\b
+     | \b((?:AD|BZ|CCHBCK|CFG|COPS|DOC|ESC|FAD|LGBCK|MA|MC|MDB|MO|MOCRBCK|MOMLBCK|MR|MSC|MT|OPS|PAB|PKBMAB|PKG|PL|PM|PT|SCM|SPCP|SUP|SUPM|SUPSITE|TM|TPS|TR)-[0-9]{1,5})\b
+  ) ///i
+
+  robot.hear regex, (msg) ->
+
+    match = msg.match[1]
+
+    if msg.match[2]
+      match = msg.match[2]
+
+    msg.send "#{baseurl}/#{match}"
 


### PR DESCRIPTION
Added to the regex a list of alternates for the product keys. So if someone types "esc-788" a jira link will be created.

Prefix mechanism still available for forcing the link generation.
